### PR TITLE
Expose visitor (accept method) in the Config class

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ project (d-config)
 ###############################
 # Detect compiler and version #
 ###############################
-if(NOT CMAKE_COMPILER_IS_GNUCXX) 
+if(NOT CMAKE_COMPILER_IS_GNUCXX)
     message(FATAL_ERROR "Wrong compiler used, required g++ 4.8 or greater")
 endif()
 
@@ -65,7 +65,7 @@ add_definitions(-DHOOLA_CACHE_LINE_SIZE=${HOOLA_CACHE_LINE_SIZE})
 ######################
 
 add_custom_target(distclean
-    rm -rf bin lib CMakeCache.txt CMakeFiles cmake_install.cmake Makefile 
+    rm -rf bin lib CMakeCache.txt CMakeFiles cmake_install.cmake Makefile
 )
 
 ###############

--- a/README.md
+++ b/README.md
@@ -237,7 +237,7 @@ std::vector<int32_t> values = config.getAll<int32_t>("Config.Array.");
 ```
 or
 ```cpp
-std::vector<int32_t> values = config.scope("Config.Array").getAll<int32_t>("");
+std::vector<int32_t> values = config.scope("Config.Array").getAll<int32_t>(".");
 ```
 Corresponding json file:
 ```json

--- a/src/config.hpp
+++ b/src/config.hpp
@@ -28,7 +28,7 @@ class Config
     template<typename V>
     struct Visitor
     {
-        explicit Visitor(V&& visitor, Separator separator)
+        Visitor(V&& visitor, Separator separator)
             : separator(separator)
             , visitor{std::forward<V>(visitor)}
         {}

--- a/src/config_node.hpp
+++ b/src/config_node.hpp
@@ -9,26 +9,25 @@
 #include <separator.hpp>
 
 //boost
-#include <boost/multi_index_container.hpp>
-#include <boost/multi_index/sequenced_index.hpp>
-#include <boost/multi_index/ordered_index.hpp>
-#include <boost/multi_index/hashed_index.hpp>
-#include <boost/multi_index/identity.hpp>
-#include <boost/multi_index/member.hpp>
-#include <boost/multi_index/mem_fun.hpp>
-#include <boost/utility/string_ref.hpp>
 #include <boost/algorithm/string.hpp>
 #include <boost/algorithm/string/split.hpp>
 #include <boost/functional/hash.hpp>
+#include <boost/multi_index_container.hpp>
+#include <boost/multi_index/hashed_index.hpp>
+#include <boost/multi_index/identity.hpp>
+#include <boost/multi_index/mem_fun.hpp>
+#include <boost/multi_index/member.hpp>
+#include <boost/multi_index/ordered_index.hpp>
+#include <boost/multi_index/sequenced_index.hpp>
+#include <boost/utility/string_ref.hpp>
 
 //std
-#include <memory>
-//#include <utility>
-#include <vector>
-#include <string>
-#include <functional>
 #include <cstring>
+#include <functional>
 #include <limits>
+#include <memory>
+#include <string>
+#include <vector>
 
 namespace dconfig {
 namespace detail {
@@ -304,7 +303,7 @@ public:
             size_t index = 0;
             for (auto&& node : child.value)
             {
-                visitor.visit(*this, child.key, index++, *node);
+                visitor.visit(shared_from_this(), child.key, index++, node);
             }
         }
         for(auto&& child : values.get<sequenced>())
@@ -313,7 +312,7 @@ public:
             for (auto&& value : child.value)
             {
                 //NOTE: const_cast is safe here as we are not touching the key
-                visitor.visit(*this, child.key, index++, const_cast<std::string&>(value));
+                visitor.visit(shared_from_this(), child.key, index++, const_cast<std::string&>(value));
             }
         }
     }
@@ -324,10 +323,9 @@ private:
     {
         for (const auto& child : nodes.get<sequenced>())
         {
-            stream  << std::endl
-                    << indent << child.key
-                    << " ("   << std::hex << this << ")"
-                    << " -> " << std::hex << parent.get();
+            stream  << "\n"    << indent << child.key
+                    << " ("    << std::hex << this << ")"
+                    << " -> "  << std::hex << parent.get();
             for (const auto& node : child.value)
             {
                 node->print(stream, indent + "    ");
@@ -335,13 +333,12 @@ private:
         }
         for (const auto& child : values.get<sequenced>())
         {
-            stream  << std::endl
-                    << indent << child.key << " = [";
+            stream  << "\n"    << indent << child.key << " = [";
             for (const auto& value : child.value)
             {
                 stream << value << ",";
             }
-            stream << "] -> " << std::hex << parent.get();
+            stream  << "] -> " << std::hex << parent.get();
         }
     }
 

--- a/src/config_node_expander.hpp
+++ b/src/config_node_expander.hpp
@@ -52,7 +52,7 @@ class ConfigNodeExpander
             assert(result);
         }
 
-        void visit(detail::ConfigNode& parent, const std::string& key, size_t index, std::string& value)
+        void visit(detail::ConfigNode::node_type const& parent, const std::string& key, size_t index, std::string& value)
         {
             using namespace boost::xpressive;
 
@@ -62,12 +62,12 @@ class ConfigNodeExpander
                 if (what.size() > 3)
                 {
                     auto&& path = what[3].str();
-                    auto scope = resolveScope(what, &parent);
-                    if (scope && addKeyNode(scope, &parent, key, index, path))
+                    auto scope = resolveScope(what, parent.get());
+                    if (scope && addKeyNode(scope, parent.get(), key, index, path))
                         return;
 
                     //for backward compatiblity fallback to node scope
-                    if (scope == root && addKeyNode(&parent, &parent, key, index, path))
+                    if (scope == root && addKeyNode(parent.get(), parent.get(), key, index, path))
                         return;
                 }
 
@@ -78,9 +78,9 @@ class ConfigNodeExpander
             }
         }
 
-        void visit(detail::ConfigNode&, const std::string&, size_t, detail::ConfigNode& node)
+        void visit(detail::ConfigNode::node_type const&, const std::string&, size_t, detail::ConfigNode::node_type const& node)
         {
-            node.accept(*this);
+            node->accept(*this);
         }
 
     private:
@@ -124,8 +124,8 @@ class ConfigNodeExpander
                 }
             }
 
-            auto&& baseKeyNode = getBaseNode(scope, from);
-            if (baseKeyNode.node)
+            if (auto&& baseKeyNode = getBaseNode(scope, from);
+                baseKeyNode.node)
             {
                 auto findIt = result->find(baseKeyNode.node.get());
                 if (findIt != result->end())

--- a/src/config_param_expander.hpp
+++ b/src/config_param_expander.hpp
@@ -111,11 +111,11 @@ class ConfigParamExpander
             assert(levelUp);
         }
 
-        void visit(detail::ConfigNode& parent, const std::string& key, size_t index, std::string& value)
+        void visit(detail::ConfigNode::node_type const& parent, const std::string& key, size_t index, std::string& value)
         {
             try
             {
-                value = boost::xpressive::regex_replace(value, *match, RegexExpander(root, &parent, separator, levelUp));
+                value = boost::xpressive::regex_replace(value, *match, RegexExpander(root, parent.get(), separator, levelUp));
             }
             catch (const std::invalid_argument&)
             {
@@ -126,9 +126,9 @@ class ConfigParamExpander
             }
         }
 
-        void visit(detail::ConfigNode&, const std::string&, size_t, detail::ConfigNode& node)
+        void visit(detail::ConfigNode::node_type const&, const std::string&, size_t, detail::ConfigNode::node_type const& node)
         {
-            node.accept(*this);
+            node->accept(*this);
         }
 
         const boost::xpressive::sregex* match;

--- a/src/file_factory.cpp
+++ b/src/file_factory.cpp
@@ -14,11 +14,10 @@ namespace dconfig {
 
 Config FileFactory::create() const
 {
-    std::vector<std::string> contents;
+    auto contents = std::vector<std::string>{};
     for(auto&& filename : files)
-    {        
-        std::ifstream in(filename, std::ios::in | std::ios::binary);
-        if (in)
+    {
+        if (auto in = std::ifstream{filename, std::ios::in | std::ios::binary})
         {
             std::string loaded;
             in.seekg(0, std::ios::end);

--- a/src/file_factory.hpp
+++ b/src/file_factory.hpp
@@ -20,8 +20,8 @@ namespace dconfig
 struct FileFactory
 {
     template<typename T>
-    explicit FileFactory(T&& aFileList, Separator separator = Separator(), ArrayKey arrayKey = ArrayKey())
-        : files(std::forward<T>(aFileList))
+    explicit FileFactory(T&& fileList, Separator separator = Separator(), ArrayKey arrayKey = ArrayKey())
+        : files(std::forward<T>(fileList))
         , separator(separator)
         , arrayKey(arrayKey)
     {

--- a/test/unit/config_visitor_should.cpp
+++ b/test/unit/config_visitor_should.cpp
@@ -1,0 +1,43 @@
+//          Copyright Adam Lach 2017
+// Distributed under the Boost Software License, Version 1.0.
+//    (See accompanying file LICENSE_1_0.txt or copy at
+//          http://www.boost.org/LICENSE_1_0.txt)
+
+//gmock
+#include <gmock/gmock.h>
+
+//config
+#include <config.hpp>
+#include <default_builder.hpp>
+
+//std
+#include <string>
+
+using testing::Test;
+using testing::_;
+
+namespace test::dconfig {
+namespace {
+
+auto config = ::dconfig::DefaultBuilder().build({std::string{R"(
+{
+    "key"    : "value",
+    "array"  : [1,2,4,5],
+    "nested" :
+    {
+        "key"   : "eulav",
+        "array" : [9,8,7]
+    }
+})"}});
+
+struct ConfigVisitorShould : ::testing::Test {};
+
+TEST_F(ConfigVisitorShould, beCool)
+{
+    // config.accept([](auto node, auto value_or_node) {
+
+    // });
+}
+
+} // namespace
+} // namespace test::dconfig

--- a/test/unit/config_visitor_should.cpp
+++ b/test/unit/config_visitor_should.cpp
@@ -12,9 +12,9 @@
 
 //std
 #include <string>
+#include <unordered_map>
 
-using testing::Test;
-using testing::_;
+using namespace testing;
 
 namespace test::dconfig {
 namespace {
@@ -22,6 +22,7 @@ namespace {
 auto config = ::dconfig::DefaultBuilder().build({std::string{R"(
 {
     "key"    : "value",
+    "key2"   : 1234567,
     "array"  : [1,2,4,5],
     "nested" :
     {
@@ -30,13 +31,72 @@ auto config = ::dconfig::DefaultBuilder().build({std::string{R"(
     }
 })"}});
 
-struct ConfigVisitorShould : ::testing::Test {};
+struct ConfigVisitorShould : Test {};
 
-TEST_F(ConfigVisitorShould, beCool)
+TEST_F(ConfigVisitorShould, beCalledWithAllKeyValues)
 {
-    // config.accept([](auto node, auto value_or_node) {
+    auto values = std::unordered_map<std::string, std::string>{};
+    config.accept([&values](std::string const& key, auto value_or_node) {
+        if constexpr (std::is_same_v<decltype(value_or_node), std::string>)
+            values.emplace(key, value_or_node);
+    });
+    EXPECT_FALSE(values.empty());
 
-    // });
+    EXPECT_TRUE(values.count("key"));
+    EXPECT_EQ(std::string{"value"}, values.find("key")->second);
+
+    EXPECT_TRUE(values.count("key2"));
+    EXPECT_EQ(std::string{"1234567"}, values.find("key2")->second);
+}
+
+TEST_F(ConfigVisitorShould, beCalledWithNestedConfigs)
+{
+    auto values = std::unordered_map<std::string, ::dconfig::Config>{};
+    config.accept([&values](std::string const& key, auto value_or_node) {
+        if constexpr (std::is_same_v<decltype(value_or_node), ::dconfig::Config>)
+            values.emplace(key, value_or_node);
+    });
+    EXPECT_FALSE(values.empty());
+
+    EXPECT_TRUE(values.count("array"));
+    EXPECT_TRUE(values.count("nested"));
+}
+
+TEST_F(ConfigVisitorShould, beCalledForEachElementOfAnArray)
+{
+    auto values = std::vector<std::pair<std::string, std::string>>{};
+    config.scope("array").accept([&values](std::string const& key, auto value_or_node) {
+        if constexpr (std::is_same_v<decltype(value_or_node), std::string>)
+            values.emplace_back(key, value_or_node);
+    });
+    EXPECT_EQ(values.size(), 4);
+
+    for (auto const& [key, _] : values)
+        EXPECT_EQ(key, std::string{} + ::dconfig::ArrayKey{}.value);
+
+    EXPECT_EQ(values[0].second, std::string{"1"});
+    EXPECT_EQ(values[1].second, std::string{"2"});
+    EXPECT_EQ(values[2].second, std::string{"4"});
+    EXPECT_EQ(values[3].second, std::string{"5"});
+}
+
+TEST_F(ConfigVisitorShould, allowForRecursiveCall)
+{
+    auto values = std::unordered_map<std::string, std::string>{};
+    config.accept([&values](std::string const& key, auto value_or_node) {
+        if (key != "nested") return;
+        if constexpr (std::is_same_v<decltype(value_or_node), ::dconfig::Config>)
+            value_or_node.accept([&values](std::string const& key, auto value_or_node) {
+                if constexpr (std::is_same_v<decltype(value_or_node), std::string>) {
+                    values.emplace(key, value_or_node);
+                }
+            });
+    });
+
+    EXPECT_FALSE(values.empty());
+
+    EXPECT_TRUE(values.count("key"));
+    EXPECT_EQ(std::string{"eulav"}, values.find("key")->second);
 }
 
 } // namespace

--- a/test/unit/config_visitor_should.cpp
+++ b/test/unit/config_visitor_should.cpp
@@ -1,4 +1,4 @@
-//          Copyright Adam Lach 2017
+//          Copyright Adam Lach 2022
 // Distributed under the Boost Software License, Version 1.0.
 //    (See accompanying file LICENSE_1_0.txt or copy at
 //          http://www.boost.org/LICENSE_1_0.txt)


### PR DESCRIPTION
This PR exposes the accept method in the Config class
which was already available in the underlying ConfigNode.

This is needed so that users can inspect the Config object
without knowing the exact structure of its contents.

Implemented unit tests.