### PR TITLE
Fix memory leaks reported by asan

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ CMakeFiles/*
 CMakeCache.txt
 cmake_install.cmake
 Makefile
+compile_commands.json
 
 .kdev4/*
 dconfig.kdev4

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -102,6 +102,12 @@ target_link_libraries(unit
     pthread
 )
 
+target_compile_options(unit PRIVATE
+    -fsanitize=address)
+
+target_link_options(unit PRIVATE
+    -fsanitize=address)
+
 add_executable(perf
     ${TESTF}
     ${PERFS}

--- a/configure
+++ b/configure
@@ -5,12 +5,12 @@ mkdir -p lib
 
 if   [ "$1" = "release" ]; then
     echo "Configuring for release"
-    cmake . -G "Unix Makefiles" -DCMAKE_BUILD_TYPE=Release
+    cmake . -G "Unix Makefiles" -DCMAKE_BUILD_TYPE=Release -DCMAKE_EXPORT_COMPILE_COMMANDS=1
 elif [ "$1" = "debug"   ]; then
     echo "Configuring for debug"
-    cmake . -G "Unix Makefiles" -DCMAKE_BUILD_TYPE=Debug
+    cmake . -G "Unix Makefiles" -DCMAKE_BUILD_TYPE=Debug -DCMAKE_EXPORT_COMPILE_COMMANDS=1
 else
     echo "No build type specified, configuring for debug"
-    cmake . -G "Unix Makefiles" -DCMAKE_BUILD_TYPE=Debug
+    cmake . -G "Unix Makefiles" -DCMAKE_BUILD_TYPE=Debug -DCMAKE_EXPORT_COMPILE_COMMANDS=1
 fi
 

--- a/src/config.hpp
+++ b/src/config.hpp
@@ -33,12 +33,12 @@ class Config
             , visitor{std::forward<V>(visitor)}
         {}
 
-        void visit(detail::ConfigNode::node_type const&, const std::string& key, size_t, std::string& value)
+        void visit(const detail::ConfigNode*, const std::string& key, size_t, std::string& value)
         {
             visitor(key.empty() ? arrayKey : key, static_cast<std::string const&>(value));
         }
 
-        void visit(detail::ConfigNode::node_type const&, const std::string& key, size_t, detail::ConfigNode::node_type const& node)
+        void visit(const detail::ConfigNode*, const std::string& key, size_t, detail::ConfigNode::node_type const& node)
         {
             visitor(key, Config{node, separator});
         }

--- a/src/config_builder.cpp
+++ b/src/config_builder.cpp
@@ -33,7 +33,7 @@ ConfigBuilder::node_type buildCustomTree(const boost::property_tree::ptree& sour
     std::queue<element_type> queue;
     std::queue<element_type> next;
 
-    auto result = std::make_shared<detail::ConfigNode>();
+    auto result = detail::ConfigNode::create();
     queue.push(std::make_pair(&source, result));
     while (!queue.empty())
     {
@@ -42,7 +42,7 @@ ConfigBuilder::node_type buildCustomTree(const boost::property_tree::ptree& sour
             if (auto&& key = node.first;
                 !node.second.empty())
             {
-                auto&& insert = std::make_shared<detail::ConfigNode>();
+                auto&& insert = detail::ConfigNode::create();
                 if (!key.empty() && key[0] != arrayKey.value)
                 {
                     queue.front().second->setNode(key, insert);

--- a/src/config_param_expander.hpp
+++ b/src/config_param_expander.hpp
@@ -81,7 +81,7 @@ class ConfigParamExpander
                 auto count = (parentLevel.size() / levelUp->size());
                 for (size_t i = 0; i < count && scope; ++i)
                 {
-                    scope = scope->getParent() ? scope->getParent().get() : nullptr;
+                    scope = scope->getParent();
                 }
             }
 
@@ -111,11 +111,11 @@ class ConfigParamExpander
             assert(levelUp);
         }
 
-        void visit(detail::ConfigNode::node_type const& parent, const std::string& key, size_t index, std::string& value)
+        void visit(const detail::ConfigNode* parent, const std::string& key, size_t index, std::string& value)
         {
             try
             {
-                value = boost::xpressive::regex_replace(value, *match, RegexExpander(root, parent.get(), separator, levelUp));
+                value = boost::xpressive::regex_replace(value, *match, RegexExpander(root, parent, separator, levelUp));
             }
             catch (const std::invalid_argument&)
             {
@@ -126,7 +126,7 @@ class ConfigParamExpander
             }
         }
 
-        void visit(detail::ConfigNode::node_type const&, const std::string&, size_t, detail::ConfigNode::node_type const& node)
+        void visit(const detail::ConfigNode*, const std::string&, size_t, detail::ConfigNode::node_type const& node)
         {
             node->accept(*this);
         }

--- a/test/array.json
+++ b/test/array.json
@@ -7,10 +7,5 @@
             "Elem2",
             "Elem3"
         ]
-    },
-    "InjectedArray" :
-    [
-        "%node.ConfigShould%",
-        "%node.ConfigShould%"
-    ]
+    }
 }

--- a/test/array.xml
+++ b/test/array.xml
@@ -5,8 +5,4 @@
         <.>Elem2</.>
         <.>Elem3</.>
     </Array>
-    <InjectedArray>
-        <.>%node.ConfigShould%</.>
-        <.>%node.ConfigShould%</.>
-    </InjectedArray>
 </ConfigShould>


### PR DESCRIPTION
This PR enables asan by default. Changes ConfigNode::parent 
to be a bare pointer instead of a shared_ptr. Removes 
std::enable_shared_from_this from ConfigNode. Additionally 
to that InjectedArray has been removed from array.xml.

This is needed so that there is no circular shared_ptr dependency
between different ConfigNodes and hence there is no memory
leak. With that change std::enable_shared_from_this in ConfigNode
is not needed anymore. The change in array.xml was to remove an
infinite recursive dependency from InjectedArray to ConfigShould
which in turn contained InjectedArray.

**Testing Criteria**:
- executed unit test without observing any asan reported leaks